### PR TITLE
Pass all arguments to nano

### DIFF
--- a/nani
+++ b/nani
@@ -19,4 +19,4 @@ case $number in
 		echo "Somebody was too dumb to count. Report it to @derberg:matrix.org"
 esac
 sleep 3
-nano $1
+nano "$@"


### PR DESCRIPTION
# Pass all arguments instead of only the first one.

`$1` is replaced with quoted `$@`.  This allows multiple arguments to be passed to nano.

### Example:
`nani --indicator --linenumbers filename`

Before changes the executed command would be `nano --indicator`, after the changes it contains all the arguments.